### PR TITLE
Veterinarian number validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'haml-rails', '~> 2.1'
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem 'image_processing', '~> 1.2'
 
+# Phonelib is a gem allowing you to validate phone number.
+gem 'phonelib'
+
 gem 'net-smtp', require: false
 gem 'net-imap', require: false
 gem 'net-pop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,7 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.19.1-x86_64-darwin)
       racc (~> 1.4)
+    phonelib (0.10.16)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -284,6 +285,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  phonelib
   propshaft
   puma (>= 5.0)
   rack-mini-profiler (~> 3.0)

--- a/app/controllers/veterinarians_controller.rb
+++ b/app/controllers/veterinarians_controller.rb
@@ -16,9 +16,10 @@ class VeterinariansController < ApplicationController
 
   def create
     @veterinarian = Veterinarian.new(veterinarian_params)
+    is_valid_phone_number = @veterinarian.number.present? && @veterinarian.number.match?(Veterinarian::PHONE_REGEXP)
 
     respond_to do |format|
-      if @veterinarian.save
+      if is_valid_phone_number && @veterinarian.save
         format.html { redirect_to @veterinarian, notice: 'Veterinarian was successfully created.' }
         format.json { render :show, status: :created, location: @veterinarian }
       else

--- a/app/models/veterinarian.rb
+++ b/app/models/veterinarian.rb
@@ -1,3 +1,7 @@
 class Veterinarian < ApplicationRecord
   has_many :tests, dependent: :restrict_with_exception
+
+  PHONE_REGEXP = /\A\+[1-9]\d{6,14}\z/
+
+  validates :number, format: { with: PHONE_REGEXP }, on: :create
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,10 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      models:
+        veterinarian:
+          attributes:
+            number:
+              invalid: "must be in international format (e.g. +14155552671)"

--- a/test/models/veterinarian_test.rb
+++ b/test/models/veterinarian_test.rb
@@ -1,7 +1,19 @@
 require "test_helper"
 
 class VeterinarianTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def build_vet(number)
+    Veterinarian.new(name: "Dr. Test", status: "available", admin: false, number: number)
+  end
+
+  # Valid numbers
+  test "accepts valid E.164 number with country code" do
+    assert build_vet("+14155552671").valid?
+  end
+
+  # Invalid numbers
+  test "rejects number without leading +" do
+    vet = build_vet("14155552671")
+    assert vet.invalid?
+    assert_includes vet.errors[:number], I18n.t("activerecord.errors.models.veterinarian.attributes.number.invalid")
+  end
 end


### PR DESCRIPTION
| 👀 𝘈𝘉𝘖𝘜𝘛 |
|---------------|

Add international phone number validation (E.164 format) to the Veterinarian model, with the  error message extracted into the en.yml locale file rather than hardcoded in the model, and  covered by unit tests for both valid and invalid number formats   

| 🎉 𝘞𝘏𝘈𝘛 𝘊𝘏𝘈𝘕𝘎𝘌𝘋 |
|----------------------------|

- added veterinarian model validations for  international phone number
- added a new locales for the validation error message


| 📄️ 𝘋𝘖𝘊𝘜𝘔𝘌𝘕𝘛𝘈𝘛𝘐𝘖𝘕 𝘓𝘐𝘕𝘒𝘚 |
|-------------------------------------------|

- Requirements  ⇢ https://github.com/jkidd86/tracefirst-interview-code-test-stsang/issues/2#issue-4017159406

| ✏️ 𝘕𝘖𝘛𝘌 |
|-------------|


<details>
<summary>Screenshot of the validation - local development </summary>
<br>

![Trace First Code Test](https://github.com/user-attachments/assets/8f39daad-694f-4f29-9b04-2007135f37d1)

</details>

| ✅ 𝘊𝘏𝘌𝘊𝘒𝘓𝘐𝘚𝘛 |
|----------------------|

- [x] I have performed a self-review of my code and tested my change locally
- [x] I have made corresponding changes to the documentation as needed
- [x] I have added tests that prove my fix is effective or that my feature works


> **🤜🤛**  𝒯𝒽𝒶𝓃𝓀 𝓎𝑜𝓊 𝒻𝑜𝓇 𝓎𝑜𝓊𝓇 𝓇𝑒𝓋𝒾𝑒𝓌