### PR TITLE
Validate new Veterinarian number and make sure its international

### DIFF
--- a/app/models/veterinarian.rb
+++ b/app/models/veterinarian.rb
@@ -3,4 +3,7 @@ class Veterinarian < ApplicationRecord
 
 #   ADD IN NEW SCOP WHERE ACTIVE ONLY SHOWS WHEN is_deleted IS FLASE OR EMPTY
   scope :active, -> { where(is_deleted: [false, nil] )}
+
+#   ADD VALID INTERNATIONAL NUMBER CHECK
+  validates :number, format: { with:  /\A\+[1-9]\d{1,14}\z/, message: " must be valid international phone number format"}
 end

--- a/test/controllers/veterinarians_controller_test.rb
+++ b/test/controllers/veterinarians_controller_test.rb
@@ -20,7 +20,7 @@ class VeterinariansControllerTest < ActionDispatch::IntegrationTest
       post veterinarians_url, params: { veterinarian: { name: 'Karl',
                                                         status: 'available',
                                                         admin: false,
-                                                        number: '+09876589365' } }
+                                                        number: '+449876589365' } }
     end
 
     assert_redirected_to veterinarian_url(Veterinarian.last)
@@ -40,7 +40,7 @@ class VeterinariansControllerTest < ActionDispatch::IntegrationTest
     patch veterinarian_url(@veterinarian), params: { veterinarian: { name: 'Karl',
                                                                      status: 'unavailable',
                                                                      admin: false,
-                                                                     number: '+09876989365' } }
+                                                                     number: '+449876989365' } }
     assert_redirected_to veterinarian_url(@veterinarian)
   end
 
@@ -56,5 +56,20 @@ class VeterinariansControllerTest < ActionDispatch::IntegrationTest
           x.update(is_deleted: true)
           get veterinarian_url(@veterinarian)
           assert_response :success
+     end
+
+     test 'vet number is international' do
+          x = veterinarians(:veterinarian_one)
+          assert x.valid?, "Number is valid"
+     end
+
+     test 'vet number is not international' do
+          x = Veterinarian.new(
+               name: "Invalid",
+               status: "Busy",
+               admin: false,
+               number: "12345"
+          )
+          assert_not x.valid?, "Number is not international"
      end
 end

--- a/test/fixtures/veterinarians.yml
+++ b/test/fixtures/veterinarians.yml
@@ -8,7 +8,7 @@ veterinarian_one:
   name: "Bob"
   status: "available"
   admin: false
-  number: "+08763728495"
+  number: "+448763728495"
 
 veterinarian_two:
   name: "Jane"


### PR DESCRIPTION
- Updated some fixture phone numbers to ensure they follow the international format, so tests pass when running bin/rails test.
- Added model tests to verify the expected behaviour of the international number validation.
- Included a test with an invalid phone number to confirm validation rejects it.
- Implemented the validation in the Veterinarian model using a regex to enforce the correct international number format.